### PR TITLE
Removing utf-8 character from comment

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -71,7 +71,7 @@ Parameters:
     NoEcho: true
     Default: ''
   SubDomainNameWithDot:
-    Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires HostedZoneModule parameter!'
+    Description: 'Name that is used to create the DNS entry with trailing dot, e.g. ${SubDomainNameWithDot}${HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires HostedZoneModule parameter!'
     Type: String
     Default: 'aurora.'
   PreferredBackupWindow:


### PR DESCRIPTION
Hi,
With the latest aws cli running on an ubuntu server I was not able to run `aws cloudformation package` with these characters in the template. I'm assuming they were intended to be $ signs anyway so hopefully this is a simple one.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
