### PR TITLE
add mysql 5.7 LTS release

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ none
       <td>Aurora Serverless MySQL version</td>
       <td>5.6.10a</td>
       <td>no</td>
-      <td>['5.6.10a']</td>
+      <td>['5.6.10a', '5.7.mysql-aurora.2.04.9', '5.7.mysql-aurora.2.07.1']</td>
     </tr>
     <tr>
       <td>EnableDataApi</td>

--- a/module.yml
+++ b/module.yml
@@ -107,7 +107,7 @@ Parameters:
     Description: 'Aurora Serverless MySQL version.'
     Type: String
     Default: '5.6.10a'
-    AllowedValues: ['5.6.10a', '5.7.mysql-aurora.2.07.1'] # aws rds describe-db-engine-versions --engine aurora --query 'DBEngineVersions[?contains(SupportedEngineModes,`serverless`)]'; aws rds describe-db-engine-versions --engine aurora-mysql --query 'DBEngineVersions[?contains(SupportedEngineModes,`serverless`)]'
+    AllowedValues: ['5.6.10a', '5.7.mysql-aurora.2.04.9', '5.7.mysql-aurora.2.07.1'] # aws rds describe-db-engine-versions --engine aurora --query 'DBEngineVersions[?contains(SupportedEngineModes,`serverless`)]'; aws rds describe-db-engine-versions --engine aurora-mysql --query 'DBEngineVersions[?contains(SupportedEngineModes,`serverless`)]'
   EnableDataApi:
     Description: 'Enable the Data API (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html).'
     Type: String
@@ -119,6 +119,10 @@ Mappings:
       ClusterParameterGroupFamily: 'aurora5.6'
       EngineVersion: '5.6.10a'
       Engine: aurora
+    '5.7.mysql-aurora.2.04.9':
+      ClusterParameterGroupFamily: 'aurora-mysql5.7'
+      EngineVersion: '5.7.mysql_aurora.2.04.9'
+      Engine: 'aurora-mysql'
     '5.7.mysql-aurora.2.07.1':
       ClusterParameterGroupFamily: 'aurora-mysql5.7'
       EngineVersion: '5.7.mysql_aurora.2.07.1'


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Added EngineVersion "5.7.mysql_aurora.2.04.9" which is the current LTS release.